### PR TITLE
Fix hashing function bug for password generation

### DIFF
--- a/lib/helper/hashing.dart
+++ b/lib/helper/hashing.dart
@@ -52,7 +52,7 @@ class Hashing {
     for (var i = 0; i < loops; i++) {
       bytes = (configuration.hashingFunction)
           ? generateSHA512(output)
-            : generateMD5(output);
+          : generateMD5(output);
       output = (configuration.hashingAlgorithm)
           ? convertBytesToStringSGP(bytes)
           : convertBytesToStringKG(bytes);

--- a/lib/helper/hashing.dart
+++ b/lib/helper/hashing.dart
@@ -51,8 +51,8 @@ class Hashing {
     if (configuration.hashingAlgorithm) loops = 10;
     for (var i = 0; i < loops; i++) {
       bytes = (configuration.hashingFunction)
-          ? generateMD5(output)
-          : generateSHA512(output);
+          ? generateSHA512(output)
+            : generateMD5(output);
       output = (configuration.hashingAlgorithm)
           ? convertBytesToStringSGP(bytes)
           : convertBytesToStringKG(bytes);


### PR DESCRIPTION
There was an issue where the hashing algorithm used was reversed. MD5 resulted in SHA512 and vice versa